### PR TITLE
Alg exception

### DIFF
--- a/draft-ietf-tls-iana-registry-updates.md
+++ b/draft-ietf-tls-iana-registry-updates.md
@@ -2,7 +2,7 @@
 title: D/TLS IANA Registry Updates
 abbrev: D/TLS IANA Registry Updates
 docname: draft-ietf-tls-iana-registry-updates-latest
-date: 2017-01-02
+date: {DATE}
 category: std
 updates: 3749, 5077, 4680, 5246, 5878, 6520, 7301
 

--- a/draft-ietf-tls-iana-registry-updates.md
+++ b/draft-ietf-tls-iana-registry-updates.md
@@ -169,6 +169,8 @@ IANA is to update the TLS Cipher Suite registry as follows:
 
 The cipher suites that follow are standards track server-authenticated (and optionally client-authenticated) cipher suites which are currently available in TLS 1.2. The notable exception are the ECDHE AES GCM cipher suites which are not yet standards track prior to the publication of this specification, but this document promotes those 4 cipher suites to standards track (see TO-DO insert reference).
 
+RFC EDITOR: Please delete the sentence beginning with "The notable exception ..." after RFC 5289 has been promoted to Proposed Standard.
+
 ~~~
 Cipher Suite Name                             | Value
 ----------------------------------------------+------------


### PR DESCRIPTION
Adding instructions for the RFC editor to delete the sentence that notes the algorithms defined in RFC 5289 as these algorithms will be standards track at or before the time this draft gets to the RFC editor.