### PR TITLE
fixing up reserved values in hash and signature algorithms registry

### DIFF
--- a/draft-ietf-tls-iana-registry-updates.md
+++ b/draft-ietf-tls-iana-registry-updates.md
@@ -600,8 +600,8 @@ Compression Method Identifiers, TLS HashAlgorithm and TLS
 SignatureAlgorithm registries to also refer to this document.
 
 - [SHALL update/has updated] the TLS HashAlgorithm Registry to list
-values 7-223 as "Reserved" and the TLS SignatureAlgorithm registry to
-list values 4-223 as "Reserved".
+values 7 and 9-223 as "Reserved" and the TLS SignatureAlgorithm
+registry to list values 4-6 and 9-223 as "Reserved".
 
 Despite the fact that the HashAlgorithm and SignatureAlgorithm
 registries are orphaned, it is still import to warn implementers of


### PR DESCRIPTION
4492bis includes some values we were marking as reserved and that's wrong.

We also have 224-255 that we might also mark as reserved.  Effectively, this closes these two registries.