### PR TITLE
reserving values and pointing

### DIFF
--- a/draft-ietf-tls-iana-registry-updates.md
+++ b/draft-ietf-tls-iana-registry-updates.md
@@ -683,7 +683,8 @@ protocol version 1.3 or later.
 
 Note:
 : The values in this registry are only applicable to (D)TLS protocol
-versions prior to 1.3.
+versions prior to 1.3.  (D)TLS 1.3 and later versions' values are
+registered in the TLS SignatureScheme registry.
 
 - [SHALL update/has updated] the "Reference" field in the TLS
 Compression Method Identifiers, TLS HashAlgorithm and TLS


### PR DESCRIPTION
An open issue was whether to close the HashAlgorithms and SignatureAlgorithms registries or just reserve the values and point to the new 1.3 schemes.

WRT opening a closed registry, IANA told me that opening a closed registry required another RFC or if we put in the IANA considerations section IESG Approval.  With that info and the fact that at least one person was like "woah wait I might need to register some algorithms for TLS1.2", I don’t really see the point in closing the registry so I propose that we leave it as is, but that we update the text as noted in the PR to explicit point to the SignatureScheme registry.